### PR TITLE
Upgrade Python packages to their latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fastapi[standard]==0.115.13
-mysql-connector-python==9.3.0
-uvicorn==0.34.3
+fastapi[standard]==0.118.0
+mysql-connector-python==9.4.0
+uvicorn==0.37.0


### PR DESCRIPTION
Upgraded the following packages in requirements.txt:
- fastapi from 0.115.13 to 0.118.0
- mysql-connector-python from 9.3.0 to 9.4.0
- uvicorn from 0.34.3 to 0.37.0

Verified that the Docker image builds successfully with the upgraded dependencies.