### PR TITLE
Fix FastAPI worker crash and improve container stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM python:3.11-alpine3.20
+FROM python:3.11-slim
 WORKDIR /code
 COPY ./requirements.txt /code/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --upgrade -r /code/requirements.txt
 COPY ./app /code/app
 CMD ["fastapi", "run", "app/main.py", "--port", "80", "--workers", "4"]

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@
 import json
 import os
 import logging
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 import pymongo
 from pymongo import MongoClient
@@ -11,12 +12,22 @@ from bson import ObjectId
 MONGO_USERNAME = os.getenv('MONGO_USERNAME')
 MONGO_PASSWORD = os.getenv('MONGO_PASSWORD')
 
-client = MongoClient('mongodb://mongodb:27017/', username=MONGO_USERNAME, password=MONGO_PASSWORD)
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI()
+# Use a global client variable but initialize it in lifespan
+client = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global client
+    logger.info("Initializing MongoDB client")
+    client = MongoClient('mongodb://mongodb:27017/', username=MONGO_USERNAME, password=MONGO_PASSWORD)
+    yield
+    logger.info("Closing MongoDB client")
+    client.close()
+
+app = FastAPI(lifespan=lifespan)
 from fastapi.middleware.cors import CORSMiddleware
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
The FastAPI application was crashing when run with multiple workers in a containerized environment (Alpine Linux). This was primarily due to the MongoDB client being initialized at the module level (before process forking) and potential compatibility issues between Alpine's musl libc and Python C extensions.

I have:
- Switched the Docker base image to `python:3.11-slim`.
- Moved `MongoClient` initialization into a FastAPI `lifespan` handler to ensure it happens after process forking.
- Added `build-essential` to the Docker build process for robust dependency installation.

Verified that the application starts successfully with 4 workers and each worker correctly initializes its own MongoDB client.

---
*PR created automatically by Jules for task [8611624801302620715](https://jules.google.com/task/8611624801302620715) started by @nmagee*